### PR TITLE
added release.package.json for use for release build.

### DIFF
--- a/lib/mix/tasks/ex2js.dist.ex
+++ b/lib/mix/tasks/ex2js.dist.ex
@@ -16,6 +16,7 @@ defmodule Mix.Tasks.Ex2js.Dist do
 
     build_standard_library
     copy_artifacts
+    npm_install
     build_tarball
 
     File.rm_rf(@folder_name)
@@ -30,9 +31,11 @@ defmodule Mix.Tasks.Ex2js.Dist do
     File.cp!("ex2js", "#{@folder_name}/bin/ex2js")
     File.cp!("priv/alphonse/alphonse.js", "#{@folder_name}/alphonse.js")
     File.cp!("priv/alphonse/dist/elixir.js", "#{@folder_name}/elixir.js")
+    File.cp!("priv/alphonse/release.package.json", "#{@folder_name}/package.json")
+  end
 
-    File.cp_r!("node_modules", "#{@folder_name}/node_modules")
-    File.cp!("package.json", "#{@folder_name}/package.json")
+  defp npm_install() do
+    System.cmd("npm", ["install"], [cd: @folder_name])   
   end
 
   defp build_tarball() do

--- a/priv/alphonse/release.package.json
+++ b/priv/alphonse/release.package.json
@@ -1,0 +1,21 @@
+{
+  "name": "elixir_script",
+  "version": "1.0.0",
+  "description": "Convert Elixir to JavaScript",
+  "main": "index.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:bryanjos/ex_to_js.git"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "escodegen": "^1.6.1"
+  }
+}


### PR DESCRIPTION
And doing `npm install` during the `mix ex2js.dist` task using it. This decreases the size of the package and only puts in what is needed to use it.